### PR TITLE
Actualizada versión que instala travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 
 before_install:
 - export TZ=America/Bogota
-- nvm install node
+- nvm install 6
 - node --version
 - nvm --version
 


### PR DESCRIPTION
Se usa versión 6 debido a que es la versión estable
resuelve #52