### PR TITLE
Filtro de enlaces mejorado

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -168,7 +168,10 @@
     });
 
 		$('#body-content').children().children().each(function(index, tag) {
-			if (tag.tagName == 'A') { $(tag).attr('target', '_blank'); }
+      var url = ($(tag).attr('href') != undefined) ? $(tag).attr('href').toLowerCase() : "";
+      if (url.indexOf("pybaq.co") >= 0) {
+			  if (tag.tagName == 'A') { $(tag).attr('target', '_blank'); }
+      }
 		});
 })(jQuery);
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Ahora valida si en el dominio del enlace se encuentra la palabra pybaq.co no abrira el enlace forma externa. Fixes #78 