### PR TITLE
Plugin lektor-markdown-highlighter

### DIFF
--- a/configs/highlighter.ini
+++ b/configs/highlighter.ini
@@ -1,0 +1,2 @@
+[pygments]
+style = tango

--- a/django-quilla.lektorproject
+++ b/django-quilla.lektorproject
@@ -5,6 +5,7 @@ url = http://pybaq.co
 [packages]
 lektor-webpack-support = 0.1
 lektor-disqus-comments = 0.2
+lektor-markdown-highlighter = 0.2
 
 [servers.ghpages]
 target = ghpages+https://PyBAQ/django-quilla-web?cname=pybaq.co


### PR DESCRIPTION
Fix: #72. Añadi el plugin lektor-markdown-highlighter para resaltar el codigo en los articulos.