### PR TITLE
Fix enlaces img

### DIFF
--- a/content/about/contents.lr
+++ b/content/about/contents.lr
@@ -1,3 +1,5 @@
+_model: page
+---
 title: Acerca de
 ---
 body:

--- a/content/eventos/contents.lr
+++ b/content/eventos/contents.lr
@@ -11,10 +11,10 @@ body:
 	<br>
 	<table class="table table-hover table-bordered table-responsive">
 	  <tr>
-	    <th>#</th>
-	    <th>Fecha</th>
-	    <th>Título</th>
-	    <th>Archivos</th>
+	    <th width="2%">#</th>
+	    <th width="20%">Fecha</th>
+	    <th width="50%">Título</th>
+	    <th width="28%">Archivos</th>
 	  </tr>
 	  <tr>
 	    <td>1</td>
@@ -133,10 +133,10 @@ body:
 	<br>
 	<table class="table table-hover table-bordered table-responsive">
 	  <tr>
-	    <th>#</th>
-	    <th>Fecha</th>
-	    <th>Título</th>
-	    <th>Archivos</th>
+	    <th width="2%">#</th>
+	    <th width="20%">Fecha</th>
+	    <th width="50%">Título</th>
+	    <th width="28%">Archivos</th>
 	  </tr>
 	  <tr>
 	    <td>19</td>
@@ -224,10 +224,10 @@ body:
 
 	<table class="table table-hover table-bordered table-responsive">
 	  <tr>
-	    <th>#</th>
-	    <th>Fecha</th>
-	    <th>Título</th>
-	    <th>Archivos</th>
+	    <th width="2%">#</th>
+	    <th width="20%">Fecha</th>
+	    <th width="50%">Título</th>
+	    <th width="28%">Archivos</th>
 	  </tr>
 	  <tr>
 	    <td>32</td>

--- a/flowblocks/text-block.ini
+++ b/flowblocks/text-block.ini
@@ -4,7 +4,7 @@ button_label = [[paragraph]]
 
 [fields.text]
 label = Text
-type = markdown
+type = html
 
 [fields.class]
 label = Class

--- a/models/page.ini
+++ b/models/page.ini
@@ -8,4 +8,4 @@ type = string
 
 [fields.body]
 label = Body
-type = markdown
+type = html


### PR DESCRIPTION
Luego del ultimo commit se daño la imagen de portada.

El motivo fue debido a que los campos en los modelos estaban marcados como markdown y los enlaces estaban como html.