### PR TITLE
Correcciones en imagenes opengraph

### DIFF
--- a/templates/blog-post.html
+++ b/templates/blog-post.html
@@ -11,7 +11,9 @@
   <meta property="og:type" content="article" />
   <meta property="og:description" content="{{ this.excerpt|striptags }}" />
   {% for image in this.attachments %}
-    <meta property="og:image" content="{{ image|url(external=True) }}}" />
+  <meta property="og:image" content="{{ image|url(external=True) }}" />
+  <meta property="og:image:width" content="{{ image.width }}" />
+  <meta property="og:image:height" content="{{ image.height }}" />
   {% endfor %}
   <meta property="og:url" content="{{ '.'|url(external=True) }}" />
   <meta property="og:site_name" content="{{ '/'|url(external=True) }}" />

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -13,7 +13,9 @@
     <meta property="og:type" content="article" />
     <meta property="og:description" content="Blog de la comunidad python Barranquilla, listado de entradas" />
     {% for image in this.attachments %}
-    <meta property="og:image" content="{{ image|url(external=True) }}}" />
+    <meta property="og:image" content="{{ image|url(external=True) }}" />
+    <meta property="og:image:width" content="{{ image.width }}" />
+    <meta property="og:image:height" content="{{ image.height }}" />
     {% endfor %}
     <meta property="og:url" content="{{ '.'|url(external=True) }}" />
     <meta property="og:site_name" content="{{ '/'|url(external=True) }}" />

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,7 +27,9 @@
     <meta property="og:type" content="article" />
     <meta property="og:description" content="Python Barranquilla es una comunidad para todos los interesados en desarrollar aplicaciones en Python dentro de la ciudad de Barranquilla." />
     {% for image in this.attachments %}
-    <meta property="og:image" content="{{ image|url(external=True) }}}" />
+    <meta property="og:image" content="{{ image|url(external=True) }}" />
+    <meta property="og:image:width" content="{{ image.width }}" />
+    <meta property="og:image:height" content="{{ image.height }}" />
     {% endfor %}
     <meta property="og:url" content="{{ '.'|url(external=True) }}" />
     <meta property="og:site_name" content="{{ '/'|url(external=True) }}" />


### PR DESCRIPTION
Actualizadas meta etiquetas de opengraph:
* Corregido error en og:image que tenia una llave
* Agregado el tamaño de og:image

http://opengraphcheck.com/result.php?url=http%3A%2F%2Fsocial.pybaq.secorto.com%2Fblog%2Fcontribuir-blog-python-barranquilla%2F#.Wpwa6OZG3eM

![screenshot_20180304_111427](https://user-images.githubusercontent.com/1175402/36947722-d439583e-1f9d-11e8-972f-fc58b59bc343.png)

![imagen](https://user-images.githubusercontent.com/1175402/36947736-feb7a03e-1f9d-11e8-9d31-747b602bc0db.png)

