### PR TITLE
Configuración https, pybaq-web

### DIFF
--- a/django-quilla.lektorproject
+++ b/django-quilla.lektorproject
@@ -1,6 +1,6 @@
 [project]
-name = django-quilla
-url = http://pybaq.co
+name = pybaq-web
+url = https://pybaq.co
 
 [packages]
 lektor-webpack-support = 0.4


### PR DESCRIPTION
# Pull request

Resuelve #122 
## Observaciones

Con este cambio se prioriza https sobre http, permitiendo que los enlaces de SEO apunten a https asi como cualquier enlace que este definido de forma absoluta, respetando la consistencia entre protocolos.