### PR TITLE
Dockerfile y documentación de su uso

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:2.7
+
+LABEL maintainer="Python Barranquilla <info@pybaq.co>"
+
+ARG LEKTOR_VERSION="3.1.3"
+
+RUN apt-get update && \
+    apt-get install -y python-dev libssl-dev libffi-dev imagemagick && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install "Lektor==$LEKTOR_VERSION"
+
+COPY . /app/
+
+WORKDIR /app
+
+ENTRYPOINT [ "lektor" ]
+CMD ["server", "-h", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 ```
 
+### Docker
+
+Si tienes Docker instalado (https://docs.docker.com/install/) puedes hacer uso del Dockerfile en el directorio principal para crear una imagen y posteriormente ejectar un contenedor con todas las dependencias necesarias. Desde el directorio principal del repositorio ejecuta:
+
+```bash
+# Bash o Powershell
+docker build -t pybaq .
+docker run --rm -p 5000:5000 -v ${PWD}:/app --name pybaq-local pybaq
+
+# Windows Command Line
+docker build -t pybaq .
+docker run --rm -p 5000:5000 -v %cd%:/app --name pybaq-local pybaq
+```
+
+Al montar la carpeta con el codigo fuente (`-v ${PWD}:/app` o `-v %cd%:/app`) los cambios que se hagan al codigo se propagaran al contenedor y se veran reflejados immediatamente.
+
+**Nota:** Verifica que el directorio donde tienes el codigo fuente puede ser montado como un Docker volume. En Linux no se requiere configuración extra, pero hay diferentes metodos para [MacOS](https://docs.docker.com/docker-for-mac/#file-sharing) y [Windows](https://blogs.msdn.microsoft.com/wael-kdouh/2017/06/26/enabling-drive-sharing-with-docker-for-windows/) dependiendo del modo de instalación.
+
 ### La discusión Python3
 
 Ahora mismo Lektor **no provee** una forma confiable y sencilla de instalar la herramienta en Linux usando Python 3. Por esto no usamos esta versión de Python. Sin embargo todos los pasos anteriormente descritos en windows funcionan sin inconvenientes usando cualquier versión de Python 3.6+. Será, sin embargo, tu responsabilidad inspeccionar el código fuente de los plugins de Lektor para segurar su compatibilidad con Python 3. Recuerda que es codigo libre y no se trata de pedir las cosas sino de contribuir a las características que deseas.


### PR DESCRIPTION
# Pull request

Closes #146

## Observaciones

En la documentación se describe que se debe crear la imagen localmente para correr el contenedor. Se debería crear una tarea para abrir un repositorio en el DockerHub, crear la imagen con Travis CI, hacerle push al DockerHub, y actualizar la documentación. 
