### PR TITLE
Traducida pagina de inicio

### DIFF
--- a/content/contents+en.lr
+++ b/content/contents+en.lr
@@ -1,0 +1,63 @@
+body:
+
+#### featured-post ####
+description:
+
+### Share knowledge in the community
+# Python Barranquilla.
+
+We are a community of web developers, dev-ops, entrepreneurs and students.
+
+Python and Django enthusiasts are invited!
+----
+link: https://pybaq.co/blog/el-zen-de-python-explicado/
+----
+image: https://pybaq.co/blog/el-zen-de-python-explicado/el-zen-de-python-explicado.png
+----
+alt: Python zen explained
+#### section-block ####
+title: Future events
+----
+body:
+
+##### meetup-events #####
+source: future_events
+-----
+anexos: 
+##### three-columns #####
+left:
+
+###### service ######
+icon: heart-o
+------
+title: Participate in the Community
+------
+body: The best thing about participating in a community is meeting amazing people with amazing dreams and projects. At each meeting we have pleasant talks where we update on the latest topics in technology, entrepreneurship and web development.
+-----
+center:
+
+###### service ######
+icon: flask
+------
+title: Get what you are looking for
+------
+body: Since we started we have characterized ourselves by helping our participants to get job opportunities or advising them to start their own ventures. Do you need web developers? This is the right place to find one.
+-----
+right:
+
+###### service ######
+icon: trophy
+------
+title: Let's Create Apps
+------
+body: We are always creating applications, either individually or as a group as a community. If you need help, this is the place where we can help you solve your doubts in the projects you have been working on. Come and participate!
+----
+class: default
+#### testimonies ####
+source: testimonies
+#### sponsors ####
+title: OUR SPONSORS
+----
+source: sponsors
+---
+title: Python Barranquilla

--- a/databags/footer.json
+++ b/databags/footer.json
@@ -19,6 +19,6 @@
         "location_title": "Our Location",
         "location_value": "Barranquilla, Atlántico, Colombia.",
         "code_of_conduct": "Code of conduct",
-        "code_of_conduct_intro": "Ours is the next"
+        "code_of_conduct_intro": "This is our"
     }
 }

--- a/databags/settings.json
+++ b/databags/settings.json
@@ -1,0 +1,8 @@
+{
+  "es": {
+    "title": "Python Barranquilla - Comunidad de Desarrollo Web",
+  },
+  "en": {
+    "title": "Python Barranquilla - Web Development Community",
+  }
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="{{ '/ico/favicon.png' | url}}">
-  <title>{% block title %}Python Barranquilla - Comunidad de Desarrollo Web{% endblock %} </title>
+  <title>{% block title %}{{bag('settings', this.alt, 'title')}}{% endblock %} </title>
   <link rel="stylesheet" href="{{ '/static/gen/styles.css'|asseturl }}">
   <link rel="stylesheet" href="{{ '/css/screen.css'|asseturl }}">
   <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->


### PR DESCRIPTION
# Pull request

Closes #209 

## Observaciones

Solo se traduce la pagina de inicio

![image](https://user-images.githubusercontent.com/1175402/88446641-64ca1880-cdf1-11ea-94bd-3f79eaf528c9.png)

La sección de eventos de meetup por su complejidad se aplaza en el momento que se cree la traducción para la pagina de los eventos ya que usan el mismo componente de meetup_events

